### PR TITLE
Add releated_underground_belt attribute

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -25,6 +25,13 @@ data.raw["splitter"]["extreme-fast-splitter"].next_upgrade = "ultra-express-spli
 data.raw["splitter"]["ultra-express-splitter"].next_upgrade = "extreme-express-splitter"
 data.raw["splitter"]["extreme-express-splitter"].next_upgrade = "original-ultimate-splitter"
 
+-- make belts able to be automatically replaced with underground belts.
+data.raw["transport-belt"]["ultra-fast-belt"].related_underground_belt="ultra-fast-underground-belt"
+data.raw["transport-belt"]["extreme-fast-belt"].related_underground_belt="extreme-fast-underground-belt"
+data.raw["transport-belt"]["ultra-express-belt"].related_underground_belt="ultra-express-underground-belt"
+data.raw["transport-belt"]["extreme-express-belt"].related_underground_belt="extreme-express-underground-belt"
+data.raw["transport-belt"]["ultimate-belt"].related_underground_belt="original-ultimate-underground-belt"
+
 if deadlock then
   --t1
   deadlock.add_tier({


### PR DESCRIPTION
Hello,
The current code doesn’t define the relationship between belts and underground belts, so when a belt is blocked by an obstacle, it doesn’t automatically get replaced with an underground belt. Adding the related_underground_belt attribute to the belt would enable automatic replacement.
I had previously implemented this feature as a separate [addon mod,](https://mods.factorio.com/mod/UltimateBeltsSmartFix) and I intended to deprecate my mod if the core mod supported this feature, but the original developer didn’t update it. I now believe that this feature should be integrated into the core mod itself.